### PR TITLE
Use 'buildx' to build multiarch JIT image

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Docker login
         uses: docker/login-action@v2
         with:
@@ -32,4 +36,4 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: true
         run: |
           export DOCKER_IMAGE=`echo "${DOCKER_REGISTRY_URL}/${DOCKER_REPOSITORY_PATH}/btcproxyd-jit" | sed -e 's#//#/#' -e 's#^/##'`
-          ./gradlew check dockerPush --no-daemon -s --info --scan
+          ./gradlew check dockerBuildxImage --no-daemon -s --info --scan

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,9 @@ test {
     environment(['MICRONAUT_CONFIG_FILES':''])
 }
 
+// TODO: See if we can use this HOW-TO to build AMD64 & ARM64: https://dev.to/cloudx/multi-arch-docker-images-the-easy-way-with-github-actions-4k54
+// See also: https://github.com/bmuschko/gradle-docker-plugin/issues/967#issuecomment-1103768609
+
 tasks.named("dockerfile") {
     baseImage = "eclipse-temurin:17-jre-jammy"
 }
@@ -109,7 +112,18 @@ dockerBuildNative {
     images = ["${System.env.DOCKER_IMAGE ?: project.name}:$project.version"]
 }
 
+def registry = 'consensusj'
+def jitImageName = "$project.name-jit"
+
+// Build and Push btcproxyd-jit for ARM64 and AMD64 architectures
+task dockerBuildxImage(type:Exec) {
+    group 'build'
+    description "Builds multiplatform image using 'docker buildx'"
+    dependsOn dockerfile, buildLayers
+    workingDir 'build/docker/main'
+    executable 'docker'
+    args = ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '-t', "$registry/$jitImageName:$project.version", '-t', "$registry/$jitImageName:latest", '--push',  '.']
+}
+
 apply from: 'gradle/asciidoctor.gradle'
 apply from: 'gradle/github-pages.gradle'
-
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-btcProxyVersion = 0.3.15
+btcProxyVersion = 0.3.17
 
 useMavenLocal = false
 


### PR DESCRIPTION
* Add Gradle task to build multiplatform (AMD64+ARM64) docker image for the `-jit` version.
* GitHub `gradle.yml` Action: docker setup QEMU & Buildx
* This image should push to our Docker registry as version 0.3.17

TODO:

1. Implement this for the Graal native-image container build
