### PR TITLE
Upgrade to Micronaut 4.0.0-RC1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,13 +53,17 @@ graalvmNative {
 
 dependencies {
     compileOnly("org.graalvm.nativeimage:svm")
-    implementation("io.micronaut:micronaut-validation")
+    implementation "io.micronaut:micronaut-jackson-databind"
     implementation("io.micronaut:micronaut-runtime")
     implementation("io.micronaut.acme:micronaut-acme")
-    implementation("javax.annotation:javax.annotation-api")
+    implementation "jakarta.annotation:jakarta.annotation-api"
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut.rxjava3:micronaut-rxjava3")
+
+    runtimeOnly "org.yaml:snakeyaml"
     runtimeOnly("ch.qos.logback:logback-classic")
+
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.72'
 
     implementation "com.msgilligan:cj-btc-jsonrpc:${consensusjVersion}"
     implementation "com.msgilligan:cj-btc-rx-jsonrpc:${consensusjVersion}"
@@ -67,15 +71,6 @@ dependencies {
     implementation "foundation.omni:omnij-jsonrpc:${omnijVersion}"
     implementation "foundation.omni:omnij-net-api:${omnijVersion}"
 }
-
-configurations.all {
-    resolutionStrategy {
-        // ConsensusJ and OmniJ are now declaring transitive dependencies on slf4j-api 2.0.0
-        // Until Micronaut upgrades, let's force the dependency back to the latest version of 1.7.x
-        force 'org.slf4j:slf4j-api:1.7.36'
-    }
-}
-
 
 application {
     mainClass.set("org.consensusj.bitcoin.proxyd.Application")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ useMavenLocal = false
 consensusjVersion = 0.6.5
 omnijVersion = 0.6.3
 
-micronautVersion=3.9.3
-micronautAppGradlePluginVersion = 3.7.10
+micronautVersion= 4.0.0-RC1
+micronautAppGradlePluginVersion = 4.0.0-M8

--- a/src/main/java/org/consensusj/bitcoin/proxy/jsonrpc/CachedRpcService.java
+++ b/src/main/java/org/consensusj/bitcoin/proxy/jsonrpc/CachedRpcService.java
@@ -10,7 +10,7 @@ import org.consensusj.jsonrpc.JsonRpcResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,6 @@
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>


### PR DESCRIPTION
I had to force bitcoinj 0.16 to use Bouncy Castle 1.72 to match the version used by `org.shredzone.acme4j:acme4j-utils`.